### PR TITLE
Added global connection from ptap to GND

### DIFF
--- a/sky130_tech/tech/sky130/lvs/sky130.lvs
+++ b/sky130_tech/tech/sky130/lvs/sky130.lvs
@@ -1670,6 +1670,8 @@ logger.info("Starting SKY130 LVS connectivity setup (Global connections)")
 
 # Global
 connect_global(sub  , substrate_name)
+connect_global(ptap_conn  , substrate_name)
+
 
 logger.info("Starting SKY130 LVS connectivity setup (Multifinger Devices)")
 


### PR DESCRIPTION
Hi there,

There has been issues with LVS failing due to ptap not being connected to global ground. This PR is a fix for that issue. 
Looking forward for your review!!
