### PR TITLE
Fix Copyright Headers

### DIFF
--- a/.github/workflows/testing_lvs.yml
+++ b/.github/workflows/testing_lvs.yml
@@ -1,17 +1,16 @@
 # Copyright 2022 Mabrains
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 name: Regression testing non fixed devices and other fixed devices than RF MOSFET
 concurrency:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+
 # Byte-compiled / optimized / DLL files
 
 __pycache__/

--- a/sky130_tech/tech/sky130/lvs/run_lvs.py
+++ b/sky130_tech/tech/sky130/lvs/run_lvs.py
@@ -1,17 +1,16 @@
-# Copyright 2022 Efabless Cooperation
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 
 """Run Skywater 130nm LVS.

--- a/sky130_tech/tech/sky130/lvs/sky130.lvs
+++ b/sky130_tech/tech/sky130/lvs/sky130.lvs
@@ -1,17 +1,16 @@
-# Copyright 2022 EFabless
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 #===========================================================================================================================
 #------------------------------------------------- SKY130 LVS RULE DECK ----------------------------------------------------

--- a/sky130_tech/tech/sky130/lvs/sky130.lylvs
+++ b/sky130_tech/tech/sky130/lvs/sky130.lylvs
@@ -1,35 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <klayout-macro>
- <description/>
- <version/>
- <category>lvs</category>
- <prolog/>
- <epilog/>
- <doc/>
- <autorun>false</autorun>
- <autorun-early>false</autorun-early>
- <shortcut/>
- <show-in-menu>true</show-in-menu>
- <group-name>lvs_scripts</group-name>
- <menu-path>tools_menu.lvs.end</menu-path>
- <interpreter>dsl</interpreter>
- <dsl-interpreter-name>lvs-dsl-xml</dsl-interpreter-name>
- <text>
-# Copyright 2022 EFabless Cooperation
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-# %include sky130.lvs
-</text>
+    <description />
+    <version />
+    <category>lvs</category>
+    <prolog />
+    <epilog />
+    <doc />
+    <autorun>false</autorun>
+    <autorun-early>false</autorun-early>
+    <shortcut />
+    <show-in-menu>true</show-in-menu>
+    <group-name>lvs_scripts</group-name>
+    <menu-path>tools_menu.lvs.end</menu-path>
+    <interpreter>dsl</interpreter>
+    <dsl-interpreter-name>lvs-dsl-xml</dsl-interpreter-name>
+    <text>
+        # Copyright 2022 Efabless Corporation
+        #
+        # Licensed under the Apache License, Version 2.0 (the "License");
+        # you may not use this file except in compliance with the License.
+        # You may obtain a copy of the License at
+        #
+        # http://www.apache.org/licenses/LICENSE-2.0
+        #
+        # Unless required by applicable law or agreed to in writing, software
+        # distributed under the License is distributed on an "AS IS" BASIS,
+        # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        # See the License for the specific language governing permissions and
+        # limitations under the License.
+        # %include sky130.lvs
+    </text>
 </klayout-macro>

--- a/sky130_tech/tech/sky130/lvs/testing/Makefile
+++ b/sky130_tech/tech/sky130/lvs/testing/Makefile
@@ -1,17 +1,16 @@
-# Copyright 2022 Efabless Cooperation
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 #=========================================================================
 # ---------------------------------- LVS ---------------------------------

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/collision_test/collision.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/collision_test/collision.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT collision SUB BULK
 + C0_000 C1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/collision_test/collision_rf_fets.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/collision_test/collision_rf_fets.cdl
@@ -1,18 +1,16 @@
- 
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT collision SUBSTRATE BULK
 + SOURCE000 GATE000 DRAIN000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_bs_flash__special_sonosfet_star_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_bs_flash__special_sonosfet_star_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 .SUBCKT sky130_fd_bs_flash__special_sonosfet_star BULK_dim_fail
 + SOURCE000_dim_fail GATE000_dim_fail DRAIN000_dim_fail
 + SOURCE001_dim_fail GATE001_dim_fail DRAIN001_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_bs_flash__special_sonosfet_star_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_bs_flash__special_sonosfet_star_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 .SUBCKT sky130_fd_bs_flash__special_sonosfet_star BULK_lyr_fail
 + SOURCE000_lyr_fail GATE000_lyr_fail DRAIN000_lyr_fail
 + SOURCE001_lyr_fail GATE001_lyr_fail DRAIN001_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_bs_flash__special_sonosfet_star_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_bs_flash__special_sonosfet_star_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 .SUBCKT sky130_fd_bs_flash__special_sonosfet_star BULK_net_fail
 + SOURCE000_net_fail GATE000_net_fail DRAIN000_net_fail
 + SOURCE001_net_fail GATE001_net_fail DRAIN001_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_02p7x06p1_m1m2m3m4_shieldl1_fingercap_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_02p7x06p1_m1m2m3m4_shieldl1_fingercap_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_02p7x06p1_m1m2m3m4_shieldl1_fingercap C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_02p7x06p1_m1m2m3m4_shieldl1_fingercap_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_02p7x06p1_m1m2m3m4_shieldl1_fingercap_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_02p7x06p1_m1m2m3m4_shieldl1_fingercap C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_02p7x06p1_m1m2m3m4_shieldl1_fingercap_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_02p7x06p1_m1m2m3m4_shieldl1_fingercap_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_02p7x06p1_m1m2m3m4_shieldl1_fingercap C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_04p4x04p6_l1m1m2_noshield_o2subcell_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_04p4x04p6_l1m1m2_noshield_o2subcell_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_04p4x04p6_l1m1m2_noshield_o2subcell C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_04p4x04p6_l1m1m2_noshield_o2subcell_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_04p4x04p6_l1m1m2_noshield_o2subcell_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_04p4x04p6_l1m1m2_noshield_o2subcell C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_04p4x04p6_l1m1m2_noshield_o2subcell_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_04p4x04p6_l1m1m2_noshield_o2subcell_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_04p4x04p6_l1m1m2_noshield_o2subcell C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield_o2subcell_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield_o2subcell_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield_o2subcell C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield_o2subcell_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield_o2subcell_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield_o2subcell C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield_o2subcell_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield_o2subcell_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield_o2subcell C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_08p6x07p8_m1m2_shieldl1_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_08p6x07p8_m1m2_shieldl1_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_08p6x07p8_m1m2_shieldl1 C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_08p6x07p8_m1m2_shieldl1_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_08p6x07p8_m1m2_shieldl1_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_08p6x07p8_m1m2_shieldl1 C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_08p6x07p8_m1m2_shieldl1_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_08p6x07p8_m1m2_shieldl1_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_08p6x07p8_m1m2_shieldl1 C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_11p3x11p8_l1m1m2m3m4_shieldm5_nhv_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_11p3x11p8_l1m1m2m3m4_shieldm5_nhv_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_11p3x11p8_l1m1m2m3m4_shieldm5_nhv C0 C1 MET5
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_11p3x11p8_l1m1m2m3m4_shieldm5_nhv_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_11p3x11p8_l1m1m2m3m4_shieldm5_nhv_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_11p3x11p8_l1m1m2m3m4_shieldm5_nhv C0 C1 MET5
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_11p3x11p8_l1m1m2m3m4_shieldm5_nhv_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_11p3x11p8_l1m1m2m3m4_shieldm5_nhv_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_11p3x11p8_l1m1m2m3m4_shieldm5_nhv C0 C1 MET5
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_11p5x11p7_pol1m1m2m3m4m5_noshield_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_11p5x11p7_pol1m1m2m3m4m5_noshield_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_11p5x11p7_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_11p5x11p7_pol1m1m2m3m4m5_noshield_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_11p5x11p7_pol1m1m2m3m4m5_noshield_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_11p5x11p7_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_11p5x11p7_pol1m1m2m3m4m5_noshield_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_11p5x11p7_pol1m1m2m3m4m5_noshield_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_11p5x11p7_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_11p5x23p1_pol1m1m2m3m4m5_noshield_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_11p5x23p1_pol1m1m2m3m4m5_noshield_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_11p5x23p1_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_11p5x23p1_pol1m1m2m3m4m5_noshield_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_11p5x23p1_pol1m1m2m3m4m5_noshield_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_11p5x23p1_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_11p5x23p1_pol1m1m2m3m4m5_noshield_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_11p5x23p1_pol1m1m2m3m4m5_noshield_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_11p5x23p1_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_22p5x11p7_pol1m1m2m3m4m5_noshield_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_22p5x11p7_pol1m1m2m3m4m5_noshield_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_22p5x11p7_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_22p5x11p7_pol1m1m2m3m4m5_noshield_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_22p5x11p7_pol1m1m2m3m4m5_noshield_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_22p5x11p7_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_22p5x11p7_pol1m1m2m3m4m5_noshield_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_22p5x11p7_pol1m1m2m3m4m5_noshield_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_22p5x11p7_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_22p5x23p1_pol1m1m2m3m4m5_noshield_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_22p5x23p1_pol1m1m2m3m4m5_noshield_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_22p5x23p1_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_22p5x23p1_pol1m1m2m3m4m5_noshield_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_22p5x23p1_pol1m1m2m3m4m5_noshield_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_22p5x23p1_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_22p5x23p1_pol1m1m2m3m4m5_noshield_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_22p5x23p1_pol1m1m2m3m4m5_noshield_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_22p5x23p1_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_33p6x11p7_pol1m1m2m3m4m5_noshield_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_33p6x11p7_pol1m1m2m3m4m5_noshield_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_33p6x11p7_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_33p6x11p7_pol1m1m2m3m4m5_noshield_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_33p6x11p7_pol1m1m2m3m4m5_noshield_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_33p6x11p7_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_33p6x11p7_pol1m1m2m3m4m5_noshield_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_33p6x11p7_pol1m1m2m3m4m5_noshield_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_33p6x11p7_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_33p6x23p1_pol1m1m2m3m4m5_noshield_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_33p6x23p1_pol1m1m2m3m4m5_noshield_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_33p6x23p1_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_33p6x23p1_pol1m1m2m3m4m5_noshield_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_33p6x23p1_pol1m1m2m3m4m5_noshield_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_33p6x23p1_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_33p6x23p1_pol1m1m2m3m4m5_noshield_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_33p6x23p1_pol1m1m2m3m4m5_noshield_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_33p6x23p1_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_44p7x11p7_pol1m1m2m3m4m5_noshield_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_44p7x11p7_pol1m1m2m3m4m5_noshield_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_44p7x11p7_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_44p7x11p7_pol1m1m2m3m4m5_noshield_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_44p7x11p7_pol1m1m2m3m4m5_noshield_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_44p7x11p7_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_44p7x11p7_pol1m1m2m3m4m5_noshield_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_44p7x11p7_pol1m1m2m3m4m5_noshield_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_44p7x11p7_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield_m5pullin_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield_m5pullin_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield_m5pullin C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield_m5pullin_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield_m5pullin_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield_m5pullin C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield_m5pullin_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield_m5pullin_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield_m5pullin C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_m5pullin_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_m5pullin_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_m5pullin C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_m5pullin_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_m5pullin_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_m5pullin C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_m5pullin_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_m5pullin_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_m5pullin C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_test_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_test_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_test C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_test_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_test_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_test C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_test_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_test_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_test C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pd2nw_05v5_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pd2nw_05v5_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pd2nw_05v5 
 + D0_000_dim_fail D1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pd2nw_05v5_hvt_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pd2nw_05v5_hvt_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pd2nw_05v5_hvt 
 + D0_000_dim_fail D1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pd2nw_05v5_hvt_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pd2nw_05v5_hvt_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pd2nw_05v5_hvt 
 + D0_000_lyr_fail D1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pd2nw_05v5_hvt_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pd2nw_05v5_hvt_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pd2nw_05v5_hvt 
 + D0_000_net_fail D1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pd2nw_05v5_lvt_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pd2nw_05v5_lvt_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pd2nw_05v5_lvt 
 + D0_000_dim_fail D1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pd2nw_05v5_lvt_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pd2nw_05v5_lvt_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pd2nw_05v5_lvt 
 + D0_000_lyr_fail D1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pd2nw_05v5_lvt_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pd2nw_05v5_lvt_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pd2nw_05v5_lvt 
 + D0_000_net_fail D1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pd2nw_05v5_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pd2nw_05v5_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pd2nw_05v5 
 + D0_000_lyr_fail D1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pd2nw_05v5_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pd2nw_05v5_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pd2nw_05v5 
 + D0_000_net_fail D1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pd2nw_11v0_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pd2nw_11v0_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pd2nw_11v0 
 + D0_000_dim_fail D1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pd2nw_11v0_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pd2nw_11v0_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pd2nw_11v0 
 + D0_000_lyr_fail D1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pd2nw_11v0_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pd2nw_11v0_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pd2nw_11v0 
 + D0_000_net_fail D1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pw2nd_05v5_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pw2nd_05v5_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pw2nd_05v5 SUB
 + SUB D1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pw2nd_05v5_lvt_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pw2nd_05v5_lvt_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pw2nd_05v5_lvt SUB
 + SUB D1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pw2nd_05v5_lvt_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pw2nd_05v5_lvt_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pw2nd_05v5_lvt SUB
 + SUB D1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pw2nd_05v5_lvt_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pw2nd_05v5_lvt_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pw2nd_05v5_lvt SUB
 + SUB D1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pw2nd_05v5_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pw2nd_05v5_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pw2nd_05v5 SUB
 + SUB D1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pw2nd_05v5_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pw2nd_05v5_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pw2nd_05v5 SUB
 + SUB D1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pw2nd_05v5_nvt_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pw2nd_05v5_nvt_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pw2nd_05v5_nvt SUB
 + SUB D1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pw2nd_05v5_nvt_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pw2nd_05v5_nvt_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pw2nd_05v5_nvt SUB
 + SUB D1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pw2nd_05v5_nvt_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pw2nd_05v5_nvt_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pw2nd_05v5_nvt SUB
 + SUB D1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pw2nd_11v0_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pw2nd_11v0_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pw2nd_11v0 SUB
 + SUB D1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pw2nd_11v0_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pw2nd_11v0_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pw2nd_11v0 SUB
 + SUB D1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pw2nd_11v0_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__diode_pw2nd_11v0_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pw2nd_11v0 SUB
 + SUB D1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__model__cap_mim_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__model__cap_mim_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__model__cap_mim 
 + C0_000_dim_fail C1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__model__cap_mim_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__model__cap_mim_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__model__cap_mim 
 + C0_000_lyr_fail C1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__model__cap_mim_m4_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__model__cap_mim_m4_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__model__cap_mim_m4 
 + C0_000_dim_fail C1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__model__cap_mim_m4_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__model__cap_mim_m4_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__model__cap_mim_m4 
 + C0_000_lyr_fail C1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__model__cap_mim_m4_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__model__cap_mim_m4_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__model__cap_mim_m4 
 + C0_000_net_fail C1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__model__cap_mim_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__model__cap_mim_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__model__cap_mim 
 + C0_000_net_fail C1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_01v8_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_01v8_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__nfet_01v8 SUBSTRATE
 + SOURCE000_dim_fail GATE000_dim_fail DRAIN000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_01v8_lvt_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_01v8_lvt_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__nfet_01v8_lvt SUBSTRATE
 + SOURCE000_dim_fail GATE000_dim_fail DRAIN000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_01v8_lvt_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_01v8_lvt_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__nfet_01v8_lvt SUBSTRATE
 + SOURCE000_lyr_fail GATE000_lyr_fail DRAIN000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_01v8_lvt_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_01v8_lvt_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__nfet_01v8_lvt SUBSTRATE
 + SOURCE000_net_fail GATE000_net_fail DRAIN000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_01v8_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_01v8_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__nfet_01v8 SUBSTRATE
 + SOURCE000_lyr_fail GATE000_lyr_fail DRAIN000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_01v8_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_01v8_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__nfet_01v8 SUBSTRATE
 + SOURCE000_net_fail GATE000_net_fail DRAIN000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_03v3_nvt_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_03v3_nvt_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__nfet_03v3_nvt SUBSTRATE
 + SOURCE000_dim_fail GATE000_dim_fail DRAIN000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_03v3_nvt_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_03v3_nvt_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__nfet_03v3_nvt SUBSTRATE
 + SOURCE000_lyr_fail GATE000_lyr_fail DRAIN000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_03v3_nvt_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_03v3_nvt_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__nfet_03v3_nvt SUBSTRATE
 + SOURCE000_net_fail GATE000_net_fail DRAIN000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_05v0_nvt_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_05v0_nvt_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__nfet_05v0_nvt SUBSTRATE
 + SOURCE000_dim_fail GATE000_dim_fail DRAIN000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_05v0_nvt_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_05v0_nvt_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__nfet_05v0_nvt SUBSTRATE
 + SOURCE000_lyr_fail GATE000_lyr_fail DRAIN000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_05v0_nvt_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_05v0_nvt_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__nfet_05v0_nvt SUBSTRATE
 + SOURCE000_net_fail GATE000_net_fail DRAIN000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_g5v0d10v5_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_g5v0d10v5_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__nfet_g5v0d10v5 SUBSTRATE
 + SOURCE000_dim_fail GATE000_dim_fail DRAIN000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_g5v0d10v5_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_g5v0d10v5_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__nfet_g5v0d10v5 SUBSTRATE
 + SOURCE000_lyr_fail GATE000_lyr_fail DRAIN000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_g5v0d10v5_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__nfet_g5v0d10v5_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__nfet_g5v0d10v5 SUBSTRATE
 + SOURCE000_net_fail GATE000_net_fail DRAIN000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__npn_05v5_W1p00L1p00_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__npn_05v5_W1p00L1p00_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__npn_05v5_W1p00L1p00 B C E SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__npn_05v5_W1p00L1p00_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__npn_05v5_W1p00L1p00_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__npn_05v5_W1p00L1p00 B C E SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__npn_05v5_W1p00L1p00_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__npn_05v5_W1p00L1p00_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__npn_05v5_W1p00L1p00 B C E SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__npn_05v5_W1p00L2p00_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__npn_05v5_W1p00L2p00_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__npn_05v5_W1p00L2p00 B C E
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__npn_05v5_W1p00L2p00_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__npn_05v5_W1p00L2p00_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__npn_05v5_W1p00L2p00 B C E
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__npn_05v5_W1p00L2p00_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__npn_05v5_W1p00L2p00_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__npn_05v5_W1p00L2p00 B C E
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__npn_11v0_W1p00L1p00_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__npn_11v0_W1p00L1p00_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__npn_11v0_W1p00L1p00 B C E
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__npn_11v0_W1p00L1p00_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__npn_11v0_W1p00L1p00_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__npn_11v0_W1p00L1p00 B C E
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__npn_11v0_W1p00L1p00_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__npn_11v0_W1p00L1p00_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__npn_11v0_W1p00L1p00 B C E
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pfet_01v8_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pfet_01v8_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 .SUBCKT sky130_fd_pr__pfet_01v8 BULK_dim_fail
 + SOURCE000_dim_fail GATE000_dim_fail DRAIN000_dim_fail
 + SOURCE001_dim_fail GATE001_dim_fail DRAIN001_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pfet_01v8_hvt_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pfet_01v8_hvt_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 .SUBCKT sky130_fd_pr__pfet_01v8_hvt BULK_dim_fail
 + SOURCE000_dim_fail GATE000_dim_fail DRAIN000_dim_fail
 + SOURCE001_dim_fail GATE001_dim_fail DRAIN001_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pfet_01v8_hvt_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pfet_01v8_hvt_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 .SUBCKT sky130_fd_pr__pfet_01v8_hvt BULK_lyr_fail
 + SOURCE000_lyr_fail GATE000_lyr_fail DRAIN000_lyr_fail
 + SOURCE001_lyr_fail GATE001_lyr_fail DRAIN001_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pfet_01v8_hvt_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pfet_01v8_hvt_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 .SUBCKT sky130_fd_pr__pfet_01v8_hvt BULK_net_fail
 + SOURCE000_net_fail GATE000_net_fail DRAIN000_net_fail
 + SOURCE001_net_fail GATE001_net_fail DRAIN001_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pfet_01v8_lvt_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pfet_01v8_lvt_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 .SUBCKT sky130_fd_pr__pfet_01v8_lvt BULK_dim_fail
 + SOURCE000_dim_fail GATE000_dim_fail DRAIN000_dim_fail
 + SOURCE001_dim_fail GATE001_dim_fail DRAIN001_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pfet_01v8_lvt_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pfet_01v8_lvt_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 .SUBCKT sky130_fd_pr__pfet_01v8_lvt BULK_lyr_fail
 + SOURCE000_lyr_fail GATE000_lyr_fail DRAIN000_lyr_fail
 + SOURCE001_lyr_fail GATE001_lyr_fail DRAIN001_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pfet_01v8_lvt_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pfet_01v8_lvt_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 .SUBCKT sky130_fd_pr__pfet_01v8_lvt BULK_net_fail
 + SOURCE000_net_fail GATE000_net_fail DRAIN000_net_fail
 + SOURCE001_net_fail GATE001_net_fail DRAIN001_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pfet_01v8_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pfet_01v8_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 .SUBCKT sky130_fd_pr__pfet_01v8 BULK_lyr_fail
 + SOURCE000_lyr_fail GATE000_lyr_fail DRAIN000_lyr_fail
 + SOURCE001_lyr_fail GATE001_lyr_fail DRAIN001_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pfet_01v8_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pfet_01v8_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 .SUBCKT sky130_fd_pr__pfet_01v8 BULK_net_fail
 + SOURCE000_net_fail GATE000_net_fail DRAIN000_net_fail
 + SOURCE001_net_fail GATE001_net_fail DRAIN001_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pfet_g5v0d10v5_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pfet_g5v0d10v5_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 .SUBCKT sky130_fd_pr__pfet_g5v0d10v5 BULK_dim_fail
 + SOURCE000_dim_fail GATE000_dim_fail DRAIN000_dim_fail
 + SOURCE001_dim_fail GATE001_dim_fail DRAIN001_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pfet_g5v0d10v5_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pfet_g5v0d10v5_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 .SUBCKT sky130_fd_pr__pfet_g5v0d10v5 BULK_lyr_fail
 + SOURCE000_lyr_fail GATE000_lyr_fail DRAIN000_lyr_fail
 + SOURCE001_lyr_fail GATE001_lyr_fail DRAIN001_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pfet_g5v0d10v5_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pfet_g5v0d10v5_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 .SUBCKT sky130_fd_pr__pfet_g5v0d10v5 BULK_net_fail
 + SOURCE000_net_fail GATE000_net_fail DRAIN000_net_fail
 + SOURCE001_net_fail GATE001_net_fail DRAIN001_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__photodiode_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__photodiode_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__photodiode D0 D1
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__photodiode_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__photodiode_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__photodiode D0 D1
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__photodiode_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__photodiode_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__photodiode D0 D1
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pnp_05v5_W0p68L0p68_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pnp_05v5_W0p68L0p68_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__pnp_05v5_W0p68L0p68 Base Collector Emitter
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pnp_05v5_W0p68L0p68_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pnp_05v5_W0p68L0p68_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__pnp_05v5_W0p68L0p68 Base Collector Emitter
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pnp_05v5_W0p68L0p68_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pnp_05v5_W0p68L0p68_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__pnp_05v5_W0p68L0p68 Base Collector Emitter
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pnp_05v5_W3p40L3p40_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pnp_05v5_W3p40L3p40_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__pnp_05v5_W3p40L3p40 Base Collector Emitter
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pnp_05v5_W3p40L3p40_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pnp_05v5_W3p40L3p40_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__pnp_05v5_W3p40L3p40 Base Collector Emitter
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pnp_05v5_W3p40L3p40_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__pnp_05v5_W3p40L3p40_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__pnp_05v5_W3p40L3p40 Base Collector Emitter
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_l1_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_l1_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_l1 
 + R0_000_dim_fail R1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_l1_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_l1_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_l1 
 + R0_000_lyr_fail R1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_l1_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_l1_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_l1 
 + R0_000_net_fail R1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m1_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m1_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_m1 
 + R0_000_dim_fail R1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m1_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m1_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_m1 
 + R0_000_lyr_fail R1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m1_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m1_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_m1 
 + R0_000_net_fail R1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m2_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m2_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_m2 
 + R0_000_dim_fail R1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m2_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m2_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_m2 
 + R0_000_lyr_fail R1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m2_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m2_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_m2 
 + R0_000_net_fail R1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m3_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m3_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_m3 
 + R0_000_dim_fail R1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m3_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m3_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_m3 
 + R0_000_lyr_fail R1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m3_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m3_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_m3 
 + R0_000_net_fail R1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m4_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m4_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_m4 
 + R0_000_dim_fail R1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m4_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m4_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_m4 
 + R0_000_lyr_fail R1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m4_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m4_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_m4 
 + R0_000_net_fail R1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m5_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m5_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_m5 
 + R0_000_dim_fail R1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m5_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m5_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_m5 
 + R0_000_lyr_fail R1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m5_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_m5_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_m5 
 + R0_000_net_fail R1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_nd_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_nd_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_nd SUBSTRATE
 + R0_000_dim_fail R1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_nd_hv_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_nd_hv_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_nd_hv SUBSTRATE
 + R0_000_dim_fail R1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_nd_hv_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_nd_hv_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_nd_hv SUBSTRATE
 + R0_000_lyr_fail R1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_nd_hv_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_nd_hv_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_nd_hv SUBSTRATE
 + R0_000_net_fail R1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_nd_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_nd_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_nd SUBSTRATE
 + R0_000_lyr_fail R1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_nd_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_nd_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_nd SUBSTRATE
 + R0_000_net_fail R1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_pd_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_pd_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_pd SUBSTRATE
 + R0_000_dim_fail R1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_pd_hv_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_pd_hv_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_pd_hv SUBSTRATE
 + R0_000_dim_fail R1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_pd_hv_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_pd_hv_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_pd_hv SUBSTRATE
 + R0_000_lyr_fail R1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_pd_hv_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_pd_hv_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_pd_hv SUBSTRATE
 + R0_000_net_fail R1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_pd_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_pd_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_pd SUBSTRATE
 + R0_000_lyr_fail R1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_pd_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_pd_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_pd SUBSTRATE
 + R0_000_net_fail R1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_po_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_po_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_po 
 + R0_000_dim_fail R1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_po_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_po_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_po 
 + R0_000_lyr_fail R1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_po_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_generic_po_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_po 
 + R0_000_net_fail R1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_0p35_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_0p35_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_high_po_0p35 SUBSTRATE
 + R0_000_dim_fail R1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_0p35_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_0p35_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_high_po_0p35 SUBSTRATE
 + R0_000_lyr_fail R1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_0p35_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_0p35_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_high_po_0p35 SUBSTRATE
 + R0_000_net_fail R1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_0p69_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_0p69_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_high_po_0p69 SUBSTRATE
 + R0_000_dim_fail R1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_0p69_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_0p69_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_high_po_0p69 SUBSTRATE
 + R0_000_lyr_fail R1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_0p69_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_0p69_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_high_po_0p69 SUBSTRATE
 + R0_000_net_fail R1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_1p41_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_1p41_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_high_po_1p41 SUBSTRATE
 + R0_000_dim_fail R1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_1p41_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_1p41_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_high_po_1p41 SUBSTRATE
 + R0_000_lyr_fail R1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_1p41_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_1p41_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_high_po_1p41 SUBSTRATE
 + R0_000_net_fail R1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_2p85_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_2p85_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_high_po_2p85 SUBSTRATE
 + R0_000_dim_fail R1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_2p85_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_2p85_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_high_po_2p85 SUBSTRATE
 + R0_000_lyr_fail R1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_2p85_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_2p85_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_high_po_2p85 SUBSTRATE
 + R0_000_net_fail R1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_5p73_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_5p73_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_high_po_5p73 SUBSTRATE
 + R0_000_dim_fail R1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_5p73_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_5p73_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_high_po_5p73 SUBSTRATE
 + R0_000_lyr_fail R1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_5p73_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_high_po_5p73_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_high_po_5p73 SUBSTRATE
 + R0_000_net_fail R1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_iso_pw_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_iso_pw_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_iso_pw SUBSTRATE
 + R0_000_dim_fail R1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_iso_pw_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_iso_pw_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_iso_pw SUBSTRATE
 + R0_000_lyr_fail R1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_iso_pw_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_iso_pw_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_iso_pw SUBSTRATE
 + R0_000_net_fail R1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_0p35_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_0p35_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_xhigh_po_0p35 SUBSTRATE
 + R0_000_dim_fail R1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_0p35_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_0p35_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_xhigh_po_0p35 SUBSTRATE
 + R0_000_lyr_fail R1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_0p35_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_0p35_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_xhigh_po_0p35 SUBSTRATE
 + R0_000_net_fail R1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_0p69_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_0p69_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_xhigh_po_0p69 SUBSTRATE
 + R0_000_dim_fail R1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_0p69_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_0p69_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_xhigh_po_0p69 SUBSTRATE
 + R0_000_lyr_fail R1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_0p69_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_0p69_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_xhigh_po_0p69 SUBSTRATE
 + R0_000_net_fail R1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_1p41_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_1p41_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_xhigh_po_1p41 SUBSTRATE
 + R0_000_dim_fail R1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_1p41_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_1p41_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_xhigh_po_1p41 SUBSTRATE
 + R0_000_lyr_fail R1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_1p41_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_1p41_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_xhigh_po_1p41 SUBSTRATE
 + R0_000_net_fail R1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_2p85_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_2p85_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_xhigh_po_2p85 SUBSTRATE
 + R0_000_dim_fail R1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_2p85_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_2p85_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_xhigh_po_2p85 SUBSTRATE
 + R0_000_lyr_fail R1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_2p85_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_2p85_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_xhigh_po_2p85 SUBSTRATE
 + R0_000_net_fail R1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_5p73_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_5p73_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_xhigh_po_5p73 SUBSTRATE
 + R0_000_dim_fail R1_000_dim_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_5p73_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_5p73_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_xhigh_po_5p73 SUBSTRATE
 + R0_000_lyr_fail R1_000_lyr_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_5p73_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__res_xhigh_po_5p73_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_xhigh_po_5p73 SUBSTRATE
 + R0_000_net_fail R1_000_net_fail

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W1p00L4p00_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W1p00L4p00_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_npn_05v5_W1p00L4p00 C B E SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W1p00L4p00_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W1p00L4p00_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_npn_05v5_W1p00L4p00 C B E SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W1p00L4p00_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W1p00L4p00_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_npn_05v5_W1p00L4p00 C B E SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W1p00L8p00_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W1p00L8p00_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_npn_05v5_W1p00L8p00 C B E SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W1p00L8p00_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W1p00L8p00_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_npn_05v5_W1p00L8p00 C B E SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W1p00L8p00_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W1p00L8p00_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_npn_05v5_W1p00L8p00 C B E SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W2p00L2p00_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W2p00L2p00_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_npn_05v5_W2p00L2p00 B C E SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W2p00L2p00_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W2p00L2p00_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_npn_05v5_W2p00L2p00 B C E SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W2p00L2p00_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W2p00L2p00_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_npn_05v5_W2p00L2p00 B C E SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W2p00L4p00_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W2p00L4p00_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_npn_05v5_W2p00L4p00 C B E SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W2p00L4p00_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W2p00L4p00_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_npn_05v5_W2p00L4p00 C B E SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W2p00L4p00_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W2p00L4p00_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_npn_05v5_W2p00L4p00 C B E SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W2p00L8p00_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W2p00L8p00_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_npn_05v5_W2p00L8p00 C B E SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W2p00L8p00_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W2p00L8p00_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_npn_05v5_W2p00L8p00 C B E SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W2p00L8p00_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W2p00L8p00_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_npn_05v5_W2p00L8p00 C B E SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W5p00L5p00_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W5p00L5p00_dim_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_npn_05v5_W5p00L5p00 B C E SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W5p00L5p00_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W5p00L5p00_lyr_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_npn_05v5_W5p00L5p00 B C E SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W5p00L5p00_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_npn_05v5_W5p00L5p00_net_fail.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_npn_05v5_W5p00L5p00 B C E SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_test_coil1_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_test_coil1_dim_fail.cdl
@@ -1,17 +1,16 @@
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_test_coil1 L0 L1 TAP SUBSTRATE 
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_test_coil1_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_test_coil1_lyr_fail.cdl
@@ -1,17 +1,16 @@
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_test_coil1 L0 L1 TAP SUBSTRATE 
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_test_coil1_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_test_coil1_net_fail.cdl
@@ -1,17 +1,16 @@
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_test_coil1 L0 L1 TAP SUBSTRATE 
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_test_coil2_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_test_coil2_dim_fail.cdl
@@ -1,17 +1,16 @@
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_test_coil2 L0 L1 TAP SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_test_coil2_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_test_coil2_lyr_fail.cdl
@@ -1,17 +1,16 @@
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_test_coil2 L0 L1 TAP SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_test_coil2_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_test_coil2_net_fail.cdl
@@ -1,17 +1,16 @@
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_test_coil2 L0 L1 TAP SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_test_coil3_dim_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_test_coil3_dim_fail.cdl
@@ -1,17 +1,16 @@
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_test_coil3 L0 L1 TAP SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_test_coil3_lyr_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_test_coil3_lyr_fail.cdl
@@ -1,17 +1,16 @@
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_test_coil3 L0 L1 TAP SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_test_coil3_net_fail.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/fail_cases/sky130_fd_pr__rf_test_coil3_net_fail.cdl
@@ -1,17 +1,16 @@
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__rf_test_coil3 L0 L1 TAP SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_bs_flash__special_sonosfet_star.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_bs_flash__special_sonosfet_star.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_bs_flash__special_sonosfet_star BULK
 + SOURCE000 GATE000 DRAIN000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_02p7x06p1_m1m2m3m4_shieldl1_fingercap.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_02p7x06p1_m1m2m3m4_shieldl1_fingercap.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_02p7x06p1_m1m2m3m4_shieldl1_fingercap C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_04p4x04p6_l1m1m2_noshield_o2subcell.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_04p4x04p6_l1m1m2_noshield_o2subcell.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_04p4x04p6_l1m1m2_noshield_o2subcell C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield_o2subcell.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield_o2subcell.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_08p6x07p8_l1m1m2_noshield_o2subcell C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_08p6x07p8_m1m2_shieldl1.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_08p6x07p8_m1m2_shieldl1.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_08p6x07p8_m1m2_shieldl1 C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_11p3x11p8_l1m1m2m3m4_shieldm5_nhv.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_11p3x11p8_l1m1m2m3m4_shieldm5_nhv.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_11p3x11p8_l1m1m2m3m4_shieldm5_nhv C0 C1 MET5
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_11p5x11p7_pol1m1m2m3m4m5_noshield.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_11p5x11p7_pol1m1m2m3m4m5_noshield.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_11p5x11p7_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_11p5x23p1_pol1m1m2m3m4m5_noshield.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_11p5x23p1_pol1m1m2m3m4m5_noshield.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_11p5x23p1_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_22p5x11p7_pol1m1m2m3m4m5_noshield.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_22p5x11p7_pol1m1m2m3m4m5_noshield.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_22p5x11p7_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_22p5x23p1_pol1m1m2m3m4m5_noshield.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_22p5x23p1_pol1m1m2m3m4m5_noshield.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_22p5x23p1_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_33p6x11p7_pol1m1m2m3m4m5_noshield.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_33p6x11p7_pol1m1m2m3m4m5_noshield.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_33p6x11p7_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_33p6x23p1_pol1m1m2m3m4m5_noshield.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_33p6x23p1_pol1m1m2m3m4m5_noshield.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_33p6x23p1_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_44p7x11p7_pol1m1m2m3m4m5_noshield.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_44p7x11p7_pol1m1m2m3m4m5_noshield.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_44p7x11p7_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield_m5pullin.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield_m5pullin.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_55p8x11p7_pol1m1m2m3m4m5_noshield_m5pullin C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_m5pullin.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_m5pullin.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_m5pullin C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_test.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_test.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__cap_vpp_55p8x23p1_pol1m1m2m3m4m5_noshield_test C0 C1 SUB
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__diode_pd2nw_05v5.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__diode_pd2nw_05v5.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pd2nw_05v5 
 + D0_000 D1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__diode_pd2nw_05v5_hvt.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__diode_pd2nw_05v5_hvt.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pd2nw_05v5_hvt 
 + D0_000 D1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__diode_pd2nw_05v5_lvt.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__diode_pd2nw_05v5_lvt.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pd2nw_05v5_lvt 
 + D0_000 D1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__diode_pd2nw_11v0.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__diode_pd2nw_11v0.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pd2nw_11v0 
 + D0_000 D1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__diode_pw2nd_05v5.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__diode_pw2nd_05v5.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pw2nd_05v5 SUB
 + SUB D1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__diode_pw2nd_05v5_lvt.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__diode_pw2nd_05v5_lvt.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pw2nd_05v5_lvt SUB
 + SUB D1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__diode_pw2nd_05v5_nvt.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__diode_pw2nd_05v5_nvt.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pw2nd_05v5_nvt SUB
 + SUB D1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__diode_pw2nd_11v0.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__diode_pw2nd_11v0.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__diode_pw2nd_11v0 SUB
 + SUB D1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__model__cap_mim.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__model__cap_mim.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__model__cap_mim 
 + C0_000 C1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__model__cap_mim_m4.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__model__cap_mim_m4.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__model__cap_mim_m4 
 + C0_000 C1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__nfet_01v8.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__nfet_01v8.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__nfet_01v8 SUBSTRATE
 + SOURCE000 GATE000 DRAIN000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__nfet_01v8_lvt.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__nfet_01v8_lvt.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__nfet_01v8_lvt SUBSTRATE
 + SOURCE000 GATE000 DRAIN000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__nfet_03v3_nvt.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__nfet_03v3_nvt.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__nfet_03v3_nvt SUBSTRATE
 + SOURCE000 GATE000 DRAIN000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__nfet_05v0_nvt.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__nfet_05v0_nvt.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__nfet_05v0_nvt SUBSTRATE
 + SOURCE000 GATE000 DRAIN000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__nfet_g5v0d10v5.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__nfet_g5v0d10v5.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__nfet_g5v0d10v5 SUBSTRATE
 + SOURCE000 GATE000 DRAIN000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__npn_05v5_W1p00L1p00.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__npn_05v5_W1p00L1p00.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__npn_05v5_W1p00L1p00 C B E SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__npn_05v5_W1p00L2p00.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__npn_05v5_W1p00L2p00.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__npn_05v5_W1p00L2p00 C B E SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__npn_11v0_W1p00L1p00.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__npn_11v0_W1p00L1p00.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__npn_11v0_W1p00L1p00 C B E SUBSTRATE
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__pfet_01v8.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__pfet_01v8.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__pfet_01v8 BULK
 + SOURCE000 GATE000 DRAIN000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__pfet_01v8_hvt.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__pfet_01v8_hvt.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__pfet_01v8_hvt BULK
 + SOURCE000 GATE000 DRAIN000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__pfet_01v8_lvt.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__pfet_01v8_lvt.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__pfet_01v8_lvt BULK
 + SOURCE000 GATE000 DRAIN000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__pfet_g5v0d10v5.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__pfet_g5v0d10v5.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__pfet_g5v0d10v5 BULK
 + SOURCE000 GATE000 DRAIN000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__photodiode.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__photodiode.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__photodiode D0 D1
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__pnp_05v5_W0p68L0p68.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__pnp_05v5_W0p68L0p68.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__pnp_05v5_W0p68L0p68 Collector Base Emitter
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__pnp_05v5_W3p40L3p40.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__pnp_05v5_W3p40L3p40.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__pnp_05v5_W3p40L3p40 Collector Base Emitter
 

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_generic_l1.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_generic_l1.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_l1 
 + R0_000 R1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_generic_m1.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_generic_m1.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_m1 
 + R0_000 R1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_generic_m2.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_generic_m2.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_m2 
 + R0_000 R1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_generic_m3.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_generic_m3.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_m3 
 + R0_000 R1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_generic_m4.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_generic_m4.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_m4 
 + R0_000 R1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_generic_m5.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_generic_m5.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_m5 
 + R0_000 R1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_generic_nd.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_generic_nd.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_nd SUBSTRATE
 + R0_000 R1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_generic_nd_hv.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_generic_nd_hv.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_nd_hv SUBSTRATE
 + R0_000 R1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_generic_pd.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_generic_pd.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_pd SUBSTRATE
 + R0_000 R1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_generic_pd_hv.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_generic_pd_hv.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_pd_hv SUBSTRATE
 + R0_000 R1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_generic_po.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_generic_po.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_generic_po 
 + R0_000 R1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_high_po_0p35.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_high_po_0p35.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_high_po_0p35 SUBSTRATE
 + R0_000 R1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_high_po_0p69.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_high_po_0p69.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_high_po_0p69 SUBSTRATE
 + R0_000 R1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_high_po_1p41.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_high_po_1p41.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_high_po_1p41 SUBSTRATE
 + R0_000 R1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_high_po_2p85.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_high_po_2p85.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_high_po_2p85 SUBSTRATE
 + R0_000 R1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_high_po_5p73.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_high_po_5p73.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_high_po_5p73 SUBSTRATE
 + R0_000 R1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_iso_pw.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_iso_pw.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_iso_pw SUBSTRATE
 + R0_000 R1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_xhigh_po_0p35.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_xhigh_po_0p35.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_xhigh_po_0p35 SUBSTRATE
 + R0_000 R1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_xhigh_po_0p69.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_xhigh_po_0p69.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_xhigh_po_0p69 SUBSTRATE
 + R0_000 R1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_xhigh_po_1p41.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_xhigh_po_1p41.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_xhigh_po_1p41 SUBSTRATE
 + R0_000 R1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_xhigh_po_2p85.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_xhigh_po_2p85.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_xhigh_po_2p85 SUBSTRATE
 + R0_000 R1_000

--- a/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_xhigh_po_5p73.cdl
+++ b/sky130_tech/tech/sky130/lvs/testing/testcases/pass_cases/sky130_fd_pr__res_xhigh_po_5p73.cdl
@@ -1,18 +1,17 @@
  
 * Copyright 2022 Mabrains
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published
-* by the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-* 
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 
 .SUBCKT sky130_fd_pr__res_xhigh_po_5p73 SUBSTRATE
 + R0_000 R1_000

--- a/sky130_tech/tech/sky130/pymacros/cells/__init__.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/__init__.py
@@ -1,18 +1,17 @@
 
-# Copyright 2022 Skywater 130nm pdk development 
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 #============================================================================
 # ---------------- Pcells Generators for Klayout of sky ----------------

--- a/sky130_tech/tech/sky130/pymacros/cells/__init__.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/__init__.py
@@ -1,5 +1,5 @@
 
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/bjt.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/bjt.py
@@ -1,17 +1,16 @@
-# Copyright 2022 Skywater 130nm pdk development 
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ########################################################################################################################
 # BJT Generator for skywater130

--- a/sky130_tech/tech/sky130/pymacros/cells/bjt.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/bjt.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/cap.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/cap.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/cap.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/cap.py
@@ -1,17 +1,16 @@
-# Copyright 2022 Skywater 130nm pdk development 
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ########################################################################################################################
 # cap(Varactor-MIM) Generator for skywater130

--- a/sky130_tech/tech/sky130/pymacros/cells/diode.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/diode.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/diode.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/diode.py
@@ -1,17 +1,16 @@
-# Copyright 2022 Skywater 130nm pdk development 
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ########################################################################################################################
 # DIODE Generator for skywater130

--- a/sky130_tech/tech/sky130/pymacros/cells/draw_bjt.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/draw_bjt.py
@@ -1,18 +1,17 @@
 
-# Copyright 2022 Skywater 130nm pdk development 
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ########################################################################################################################
 ## BJT Pcells Generators for Klayout of skywater130

--- a/sky130_tech/tech/sky130/pymacros/cells/draw_bjt.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/draw_bjt.py
@@ -1,5 +1,4 @@
-
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/draw_cap.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/draw_cap.py
@@ -1,3 +1,21 @@
+# Copyright 2022 Mabrains LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+########################################################################################################################
+## Cap Pcells Generators for Klayout of skywater130
+########################################################################################################################
+
 import gdsfactory as gf
 
 from .via_generator import *

--- a/sky130_tech/tech/sky130/pymacros/cells/draw_diode.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/draw_diode.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/draw_diode.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/draw_diode.py
@@ -1,17 +1,16 @@
-# Copyright 2022 Skywater 130nm pdk development 
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ########################################################################################################################
 ## Diode Pcells Generators for Klayout of skywater130

--- a/sky130_tech/tech/sky130/pymacros/cells/draw_fet.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/draw_fet.py
@@ -1,17 +1,16 @@
-# Copyright 2022 Skywater 130nm pdk development 
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ########################################################################################################################
 ## Mosfets Pcells Generators for Klayout of skywater130

--- a/sky130_tech/tech/sky130/pymacros/cells/draw_fet.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/draw_fet.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/draw_guard_ring.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/draw_guard_ring.py
@@ -1,17 +1,16 @@
-# Copyright 2022 Skywater 130nm pdk development 
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ########################################################################################################################
 ## Guard Ring Pcells Generators for Klayout of skywater130

--- a/sky130_tech/tech/sky130/pymacros/cells/draw_guard_ring.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/draw_guard_ring.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/draw_rf.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/draw_rf.py
@@ -1,17 +1,16 @@
-# Copyright 2022 Skywater 130nm pdk development 
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ########################################################################################################################
 ## RF Devices Pcells Generators for Klayout of skywater130

--- a/sky130_tech/tech/sky130/pymacros/cells/draw_rf.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/draw_rf.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/draw_vpp.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/draw_vpp.py
@@ -1,17 +1,16 @@
-# Copyright 2022 Skywater 130nm pdk development 
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ########################################################################################################################
 ## VPP CAP Pcells Generators for Klayout of skywater130

--- a/sky130_tech/tech/sky130/pymacros/cells/draw_vpp.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/draw_vpp.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/fet.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/fet.py
@@ -1,17 +1,16 @@
-# Copyright 2022 Skywater 130nm pdk development 
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ########################################################################################################################
 # MOSFET (PFET) Generator for skywater130

--- a/sky130_tech/tech/sky130/pymacros/cells/fet.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/fet.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/globals.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/globals.py
@@ -1,17 +1,16 @@
-# Copyright 2022 Skywater 130nm pdk development 
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ########################################################################################################################
 # Global parameters generation 

--- a/sky130_tech/tech/sky130/pymacros/cells/globals.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/globals.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/gr.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/gr.py
@@ -1,17 +1,16 @@
-# Copyright 2022 Skywater 130nm pdk development 
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ########################################################################################################################
 # Guard Ring Generator for skywater130

--- a/sky130_tech/tech/sky130/pymacros/cells/gr.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/gr.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/layers_def.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/layers_def.py
@@ -1,17 +1,16 @@
-# Copyright 2022 Skywater 130nm pdk development 
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ########################################################################################################################
 # Skywater 130nm Layers  parameters generation 

--- a/sky130_tech/tech/sky130/pymacros/cells/layers_def.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/layers_def.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/parent_res.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/parent_res.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/parent_res.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/parent_res.py
@@ -1,17 +1,16 @@
-# Copyright 2022 Skywater 130nm pdk development
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # res Generator for skywater130
 

--- a/sky130_tech/tech/sky130/pymacros/cells/res_diff_child.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/res_diff_child.py
@@ -1,17 +1,16 @@
-# Copyright 2022 Skywater 130nm pdk development
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 
 # res Generator for skywater130

--- a/sky130_tech/tech/sky130/pymacros/cells/res_diff_child.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/res_diff_child.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/res_diff_klayout_panel.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/res_diff_klayout_panel.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/res_diff_klayout_panel.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/res_diff_klayout_panel.py
@@ -1,17 +1,16 @@
-# Copyright 2022 Skywater 130nm pdk development
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from .res_klayout_panel import res
 from .res_diff_child import res_diff_draw
 

--- a/sky130_tech/tech/sky130/pymacros/cells/res_klayout_panel.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/res_klayout_panel.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/res_klayout_panel.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/res_klayout_panel.py
@@ -1,17 +1,16 @@
-# Copyright 2022 Skywater 130nm pdk development
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # res Generator for skywater130
 

--- a/sky130_tech/tech/sky130/pymacros/cells/res_metal_child.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/res_metal_child.py
@@ -1,17 +1,16 @@
-# Copyright 2022 Skywater 130nm pdk development
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 
 # res Generator for skywater130

--- a/sky130_tech/tech/sky130/pymacros/cells/res_metal_child.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/res_metal_child.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/res_metal_klayout_panel.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/res_metal_klayout_panel.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/res_metal_klayout_panel.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/res_metal_klayout_panel.py
@@ -1,17 +1,17 @@
-# Copyright 2022 Skywater 130nm pdk development
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .res_klayout_panel import res
 from .res_metal_child import res_metal_draw
 

--- a/sky130_tech/tech/sky130/pymacros/cells/res_poly_child.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/res_poly_child.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/res_poly_child.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/res_poly_child.py
@@ -1,18 +1,16 @@
-# Copyright 2022 Skywater 130nm pdk development
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # res Generator for skywater130
 

--- a/sky130_tech/tech/sky130/pymacros/cells/res_poly_klayout_panel.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/res_poly_klayout_panel.py
@@ -1,17 +1,17 @@
-# Copyright 2022 Skywater 130nm pdk development
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .res_klayout_panel import res
 from .res_poly_child import res_poly_draw
 # ################constants################

--- a/sky130_tech/tech/sky130/pymacros/cells/res_poly_klayout_panel.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/res_poly_klayout_panel.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/rf.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/rf.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/rf.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/rf.py
@@ -1,17 +1,16 @@
-# Copyright 2022 Skywater 130nm pdk development 
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ########################################################################################################################
 # RF DEVICES Generator for skywater130

--- a/sky130_tech/tech/sky130/pymacros/cells/via_generator.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/via_generator.py
@@ -1,17 +1,16 @@
-# Copyright 2022 Skywater 130nm pdk development 
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ########################################################################################################################
 # via Generator for skywater130

--- a/sky130_tech/tech/sky130/pymacros/cells/via_generator.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/via_generator.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/vias.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/vias.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/cells/vias.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/vias.py
@@ -1,17 +1,16 @@
-# Copyright 2022 Skywater 130nm pdk development 
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ########################################################################################################################
 # Vias Generator for skywater130

--- a/sky130_tech/tech/sky130/pymacros/cells/vpp.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/vpp.py
@@ -1,17 +1,16 @@
-# Copyright 2022 Skywater 130nm pdk development 
+# Copyright 2022 Efabless Corporation
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-# 
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ########################################################################################################################
 # VPP CAP Generator for skywater130 

--- a/sky130_tech/tech/sky130/pymacros/cells/vpp.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/vpp.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Efabless Corporation
+# Copyright 2022 Mabrains LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sky130_tech/tech/sky130/pymacros/sky130.lym
+++ b/sky130_tech/tech/sky130/pymacros/sky130.lym
@@ -1,3 +1,19 @@
+<!--
+# Copyright 2022 Mabrains LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+
 <?xml version="1.0" encoding="utf-8"?>
 <klayout-macro>
  <description/>

--- a/sky130_tech/tech/sky130/requirements.txt
+++ b/sky130_tech/tech/sky130/requirements.txt
@@ -1,1 +1,15 @@
+# Copyright 2022 Mabrains LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 docopt==0.6.2

--- a/sky130_tech/tech/sky130/sky130.lyp
+++ b/sky130_tech/tech/sky130/sky130.lyp
@@ -1,3 +1,19 @@
+<!--
+# Copyright 2022 Mabrains LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+
 <?xml version="1.0" encoding="utf-8"?>
 <layer-properties>
  <properties>

--- a/sky130_tech/tech/sky130/sky130.lyt
+++ b/sky130_tech/tech/sky130/sky130.lyt
@@ -1,3 +1,19 @@
+<!--
+# Copyright 2022 Mabrains LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+
 <?xml version="1.0" encoding="utf-8"?>
 <technology>
  <name>sky130</name>


### PR DESCRIPTION
* Fixes license to match that in the root of the repo
* Assign copyright to misspelled and/or non-existent legal entities to Efabless Corporation as per our contractual agreement
cc @mkkassem 