### PR TITLE
Make XML files valid

### DIFF
--- a/sky130_tech/tech/sky130/sky130.lyp
+++ b/sky130_tech/tech/sky130/sky130.lyp
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 # Copyright 2022 Mabrains LLC
 #
@@ -14,7 +15,6 @@
 # limitations under the License.
 -->
 
-<?xml version="1.0" encoding="utf-8"?>
 <layer-properties>
  <properties>
   <frame-color>#ccccd9</frame-color>

--- a/sky130_tech/tech/sky130/sky130.lyt
+++ b/sky130_tech/tech/sky130/sky130.lyt
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 # Copyright 2022 Mabrains LLC
 #
@@ -14,7 +15,6 @@
 # limitations under the License.
 -->
 
-<?xml version="1.0" encoding="utf-8"?>
 <technology>
  <name>sky130</name>
  <description>SkyWater 130nm technology</description>


### PR DESCRIPTION
All valid XML files need the header tag as the very first thing in the document.

This file never had a license header. This broke OpenLane.