### PR TITLE
Rename types module to typings

### DIFF
--- a/sky130_tech/tech/sky130/pymacros/cells/draw_fet.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/draw_fet.py
@@ -21,7 +21,7 @@ from re import L
 import numpy as np
 
 import gdsfactory as gf
-from gdsfactory.types import Float2, LayerSpec
+from gdsfactory.typings import Float2, LayerSpec
 from .via_generator import * 
 from .layers_def import *
 

--- a/sky130_tech/tech/sky130/pymacros/cells/res_metal_child.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/res_metal_child.py
@@ -30,7 +30,7 @@ from .layers_def import (
     m5_layer,
 )
 from .parent_res import draw_res
-from gdsfactory.types import LayerSpec
+from gdsfactory.typings import LayerSpec
 
 # ########constants##########
 # ONLY FOR GENERIC RES

--- a/sky130_tech/tech/sky130/pymacros/cells/via_generator.py
+++ b/sky130_tech/tech/sky130/pymacros/cells/via_generator.py
@@ -20,7 +20,7 @@
 from math import ceil, floor
 from tracemalloc import start
 import gdsfactory as gf
-from gdsfactory.types import Float2 , LayerSpec
+from gdsfactory.typings import Float2 , LayerSpec
 from .layers_def import *
 
 @gf.cell


### PR DESCRIPTION
From version 6.34.0 of gdsfactory, types module was renamed to typings.