### PR TITLE
Move XML declaration to start of file for sky130.lym

### DIFF
--- a/sky130_tech/tech/sky130/pymacros/sky130.lym
+++ b/sky130_tech/tech/sky130/pymacros/sky130.lym
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 # Copyright 2022 Mabrains LLC
 #
@@ -14,7 +15,6 @@
 # limitations under the License.
 -->
 
-<?xml version="1.0" encoding="utf-8"?>
 <klayout-macro>
  <description/>
  <version/>


### PR DESCRIPTION
Moves the XML declaration to the beginning of the file to make it valid.

 Similar to #12, but it seems this file has been forgotten as it is not read when using OpenLane.